### PR TITLE
add missing param to header_column method call

### DIFF
--- a/lib/five9/client/list.rb
+++ b/lib/five9/client/list.rb
@@ -33,7 +33,7 @@ module Five9
               <fn:addToListCsv>
                 <listName>#{self.name}</listName>
                 <listUpdateSettings>
-                  #{self.header_columns}
+                  #{self.header_columns(fields)}
                   <reportEmail>admin@t2modus.com</reportEmail>
                   <separator>,</separator>
                   <skipHeaderLine>true</skipHeaderLine>


### PR DESCRIPTION
The method `def header_columns(fields)` has a param. We weren't passing it. Now we will.