### PR TITLE
fix for report request

### DIFF
--- a/lib/five9/client/base.rb
+++ b/lib/five9/client/base.rb
@@ -74,7 +74,7 @@ module Five9
             tag = array_tag.strip.split('<').second.split.first
             xml = xml.gsub(/^\s*<\/?#{Regexp.quote(tag)}( type="array")?>\s*$/, '')
           end
-          xml
+          xml.gsub!('objectName', 'objectNames')
         end
 
         def response_hash(response, key, keys_to_dig_for = nil)

--- a/lib/five9/client/campaign.rb
+++ b/lib/five9/client/campaign.rb
@@ -7,7 +7,7 @@ module Five9
     class Campaign < Base
       APPROVED_ATTRIBUTES = %w[name description mode profile_name state type].freeze
 
-      self.attr_accessor(*APPROVED_ATTRIBUTES)
+      attr_accessor(*APPROVED_ATTRIBUTES)
 
       def initialize(attributes)
         attributes.with_indifferent_access.slice(*APPROVED_ATTRIBUTES.map { |a| a.camelize(:lower) }).each do |k, v|

--- a/lib/five9/client/disposition.rb
+++ b/lib/five9/client/disposition.rb
@@ -7,7 +7,7 @@ module Five9
       APPROVED_ATTRIBUTES = %w[agent_full_name appointment call_id call_end_timestamp call_number
                                call_type_name campaign_name comments customer_id dealership_id
                                disposition_name lead_id].freeze
-      self.attr_accessor(*APPROVED_ATTRIBUTES)
+      attr_accessor(*APPROVED_ATTRIBUTES)
 
       def initialize(attributes)
         attributes.slice(*APPROVED_ATTRIBUTES.map(&:camelize)).each do |k, v|

--- a/lib/five9/client/list.rb
+++ b/lib/five9/client/list.rb
@@ -5,7 +5,7 @@ module Five9
     # This class is responsible for logic for retrieving and
     # represenging Five9 call campaigns
     class List < Base
-      self.attr_accessor :name
+      attr_accessor :name
 
       def initialize(attributes)
         attributes = attributes.with_indifferent_access


### PR DESCRIPTION
```ruby
def run_report(start_time, end_time, campaign_names)
      request_options = {
        folderName: 'T2',
        reportName: 'API',
        criteria: {
          time: {
            start: start_time.strftime('%Y-%m-%dT%H:%M:%S.%L%:z'),
            end: end_time.strftime('%Y-%m-%dT%H:%M:%S.%L%:z')
          },
          reportObjects: {
            objectNames: campaign_names,
            objectType: 'Campaign'
          }
        }
      }
      xml = xml_for_five_nine_request(:runReport, request_options)
      xml.gsub!('<objectName>', '<objectNames>')
      xml.gsub!('</objectName>', '</objectNames>')
      response = Hash.from_xml(make_api_http_request(xml))
      response.dig('Envelope', 'Body', 'runReportResponse', 'return')
    end
```

This is the method from the reporting tool. We weren't changing objectName to objectNames.